### PR TITLE
Refactor `utils.py` module

### DIFF
--- a/pydantic_aiohttp/client.py
+++ b/pydantic_aiohttp/client.py
@@ -18,7 +18,7 @@ from .errors import (
     ResponseParseError,
     errors_classes,
 )
-from .utils import chunk_file_reader
+from .utils import read_file_by_chunk
 
 StrIntMapping = dict[str, Union[str, int]]
 HttpEncodableMapping = dict[str, Union[str, int, list[Union[str, int]]]]
@@ -167,7 +167,7 @@ class Client:
             headers=headers,
             cookies=cookies,
             params=params,
-            data=chunk_file_reader(file),
+            data=read_file_by_chunk(file),
             response_model=response_model,
             timeout=timeout,
             error_response_models=error_response_models,

--- a/pydantic_aiohttp/utils.py
+++ b/pydantic_aiohttp/utils.py
@@ -3,11 +3,13 @@ from typing import Union
 
 import aiofiles
 
+DEFAULT_CHUNK_SIZE = 64 * 1024
 
-async def read_file_by_chunk(file: Union[str, PathLike[str]]):
+
+async def read_file_by_chunk(file: Union[str, PathLike[str]], chunk_size: int = DEFAULT_CHUNK_SIZE):
     async with aiofiles.open(file, 'rb') as f:
-        chunk = await f.read(64 * 1024)
+        chunk = await f.read(chunk_size)
 
         while chunk:
             yield chunk
-            chunk = await f.read(64 * 1024)
+            chunk = await f.read(chunk_size)

--- a/pydantic_aiohttp/utils.py
+++ b/pydantic_aiohttp/utils.py
@@ -4,7 +4,7 @@ from typing import Union
 import aiofiles
 
 
-async def chunk_file_reader(file: Union[str, PathLike[str]]):
+async def read_file_by_chunk(file: Union[str, PathLike[str]]):
     async with aiofiles.open(file, 'rb') as f:
         chunk = await f.read(64 * 1024)
 


### PR DESCRIPTION
Hi! I made some refactoring of `utils.py` module:
1. Changed `chunk_file_reader` function name to `read_file_by_chunk`. Function name must be verb phrase.
2. Added optional argument `chunk_size` with default value `64 * 1024`. Here i deleted duplicate values ([DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle).